### PR TITLE
change `edit` to `nano`

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -22,8 +22,9 @@ The email address should be the same one you used when setting up your GitHub ac
 
 By default, Git will open the Vi / Vim text editor to request commit messages (for example when merging conflicts).
 To avoid confusion, most people will want to change the default editor to something more familiar using the `core.editor` config. 
-Any text editor can be made default by adding the correct file path and command line options (see [GitHub help](https://help.github.com/articles/associating-text-editors-with-git/)). 
-However, the simplest `core.editor` values are `"notepad"` on Windows,  `"edit -w"` on Mac, and `"nano -w"` on Linux. 
+Any text 
+or can be made default by adding the correct file path and command line options (see [GitHub help](https://help.github.com/articles/associating-text-editors-with-git/)). 
+However, the simplest `core.editor` values are `"notepad"` on Windows,  `"nano -w"` on Mac, and `"nano -w"` on Linux. 
 For example:
 
 ~~~

--- a/setup.md
+++ b/setup.md
@@ -22,8 +22,7 @@ The email address should be the same one you used when setting up your GitHub ac
 
 By default, Git will open the Vi / Vim text editor to request commit messages (for example when merging conflicts).
 To avoid confusion, most people will want to change the default editor to something more familiar using the `core.editor` config. 
-Any text 
-or can be made default by adding the correct file path and command line options (see [GitHub help](https://help.github.com/articles/associating-text-editors-with-git/)). 
+Any text editor can be made default by adding the correct file path and command line options (see [GitHub help](https://help.github.com/articles/associating-text-editors-with-git/)). 
 However, the simplest `core.editor` values are `"notepad"` on Windows,  `"nano -w"` on Mac, and `"nano -w"` on Linux. 
 For example:
 


### PR DESCRIPTION
I don't think `edit` comes installed by default on Mac. (It's not on mine...)

On the other hand, `nano` should be there by default. It's also the [recommended text editor](https://github.com/carpentries/workshop-template/blob/gh-pages/index.md#text-editor) for Software Carpentry.

If you all prefer `edit`, perhaps we can include instructions on how to install `edit` if it's not available.