### PR TITLE
Change initial commit to no commits yet

### DIFF
--- a/_episodes/02-getting-started.md
+++ b/_episodes/02-getting-started.md
@@ -101,7 +101,7 @@ $ git status
 {: .bash}
 ~~~
 On branch master
-Initial commit
+No commits yet
 Untracked files:
   (use "git add <file>..." to include in what will be committed)
 
@@ -129,7 +129,7 @@ $ git status
 ~~~
 On branch master
 
-Initial commit
+No commits yet
 
 Changes to be committed:
   (use "git rm --cached <file>..." to unstage)
@@ -152,7 +152,7 @@ $ git status
 ~~~
 On branch master
 
-Initial commit
+No commits yet
 
 Changes to be committed:
   (use "git rm --cached <file>..." to unstage)

--- a/_episodes/02-getting-started.md
+++ b/_episodes/02-getting-started.md
@@ -69,7 +69,7 @@ $ git status
 {: .bash}
 ~~~
 On branch master
-Initial commit
+No commits yet
 nothing to commit (create/copy files and use "git add" to track)
 ~~~
 {: .output}


### PR DESCRIPTION
After `git status` the message reads:

On branch master
No commits yet
nothing to commit (create/copy files and use "git add" to track)

Change 'Initial commit' to 'No commits yet' to reflect the correct status message