### PR TITLE
Make GitHub references consistent with official capitalization.

### DIFF
--- a/_episodes/01-what-is-git.md
+++ b/_episodes/01-what-is-git.md
@@ -4,13 +4,13 @@ teaching: 10
 exercises: 0
 questions:
 - "What is Git?"
-- "What is Github?"
+- "What is GitHub?"
 objectives:
 - "recognize why version control is useful"
 - "distinguish between Git and GitHub"
 keypoints:
 - "Version control helps track changes to files and projects"
-- "Git and Github are not the same"
+- "Git and GitHub are not the same"
 ---
 
 ### What is Version Control

--- a/_episodes/05-github-pages.md
+++ b/_episodes/05-github-pages.md
@@ -1,5 +1,5 @@
 ---
-title: "Github Pages"
+title: "GitHub Pages"
 teaching: 15
 exercises: 20
 questions:

--- a/index.md
+++ b/index.md
@@ -4,7 +4,7 @@ root: .
 ---
 #### What We Will Try to Do
 
-**Begin** to understand and use Git/Github. You will not be an expert by the end of the class. You will probably not even feel very comfortable using Git. This is okay. We want to make a start but, as with any skill, using Git takes practice.
+**Begin** to understand and use Git/GitHub. You will not be an expert by the end of the class. You will probably not even feel very comfortable using Git. This is okay. We want to make a start but, as with any skill, using Git takes practice.
 
 #### Be Excellent to Each Other
 

--- a/reference.md
+++ b/reference.md
@@ -79,7 +79,7 @@ Git cheat sheet handouts:
 `git remote add origin`
 : add a repository where changes will be stored -
 
-## Useful library github repositories
+## Useful library GitHub repositories
 
 * [DavidChouinard/mrc_to_csv](https://github.com/DavidChouinard/mrc_to_csv): 'Python script for converting MARC21 files to a saner format (CSV), originally designed for the Harvard Libraries MARC21 records'
 * [Process MARC records from Python](https://github.com/edsu/pymarc)
@@ -96,8 +96,8 @@ Git cheat sheet handouts:
 
 ## Further reading
 
-* The help pages of github are a good place to start: https://help.github.com/ 
-* Github has 'activities' which aim to explain how git works: https://guides.github.com/activities/hello-world/
+* The help pages of GitHub are a good place to start: https://help.github.com/ 
+* GitHub has 'activities' which aim to explain how git works: https://guides.github.com/activities/hello-world/
 * GitHub also has a [Learning Labs](https://lab.github.com/) and an interactive tutorial via their [Desktop](https://desktop.github.com/) app
 * Some indepth but clear tutorials on using git. https://www.atlassian.com/git/tutorials
-* A website aimed at historians but useful for librarians/those interested in Digital Humanities. The project uses Github and a programme called Jekyll to manage new lessons/the website. A useful place to see a non coding use of github in action: https://programminghistorian.org 
+* A website aimed at historians but useful for librarians/those interested in Digital Humanities. The project uses GitHub and a programme called Jekyll to manage new lessons/the website. A useful place to see a non coding use of GitHub in action: https://programminghistorian.org 


### PR DESCRIPTION
This cleans up a few occurrences that didn't have the official capitalization.