### PR TITLE
Remove ways to contribute

### DIFF
--- a/index.md
+++ b/index.md
@@ -22,9 +22,3 @@ root: .
 > 2. [Install git on your own computer](https://help.github.com/articles/set-up-git/)
 > 3. [Configure your git setup]({{ page.root }}/setup/)
 {: .prereq}
-
-There are three main ways to contribute to Library Carpentry:
-
-- Join our [Gitter discussion forum]({{ site.contact }}). Here you can suggest new content, volunteer to become a lesson maintainer, or help shape future developments.
-- Suggest an improvement or correct an error by [raising an Issue](https://github.com/librarycarpentry/lc-git/issues).
-- Run a workshop at your own institution! If you do, alert us on [Gitter]({{ site.contact }}): we're happy to help promote the workshop and offer guidance on running it. Remember, there is no better way to deepen your own knowledge of software skills than to teach others.


### PR DESCRIPTION
This section is redundant since this is covered in Extras>Discussion and Contributing. Removing per https://github.com/LibraryCarpentry/lc-git/pull/53.

