### PR TITLE
Update index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -20,5 +20,5 @@ root: .
 >
 > 1. Setup a [GitHub account](https://github.com/)
 > 2. [Install git on your own computer](https://help.github.com/articles/set-up-git/)
-> 3. [Configure your git setup]({% link setup.md %})
+> 3. [Configure your git setup](setup.md)
 {: .prereq}


### PR DESCRIPTION
Clicking on "Configure your git setup" is results in 404.

Proposed Link:
https://librarycarpentry.org/lc-git/setup.html
which is expected to be generated from https://github.com/LibraryCarpentry/lc-git/blob/gh-pages/setup.md

Current Link:
https://librarycarpentry.org/setup.html
which is resulting in HTTP 404 error

Reference:
https://github.blog/2013-01-31-relative-links-in-markup-files/

Please delete this line and the text below before submitting your contribution.

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.  

---
