### PR TITLE
Fixing PR to Repo owned by someone else.

### DIFF
--- a/_episodes/05-github-pages.md
+++ b/_episodes/05-github-pages.md
@@ -101,7 +101,7 @@ Usually it's available instantly, but it can take a few seconds and in the worst
 
 > ## Challenge: Contributing to a page owned by someone else (slightly easier way)
 >
-> To practise using Git, GitHub pages and Markdown we can contribute to a GitHub pages site.
+> To practice using Git, GitHub pages and Markdown we can contribute to a GitHub pages site.
 > Pair up in groups of two (or more if needed) and do the exercises below together.
 > 
 > 1. Go to https://github.com/some-librarian/hello-world, where "some-librarian" is the username of your exercise partner.
@@ -115,11 +115,12 @@ Usually it's available instantly, but it can take a few seconds and in the worst
 >    You can preview how it will look before you commit changes.
 > 5. Once you are ready to commit, enter a short commit message,
 >    select "Create a new branch for this commit and start a pull request"
->    and press "Propose file change".
+>    and press "Propose file change" to avoid commiting directly to the master branch.
 > 
 >    ![Commit and create pull request](../fig/github-commit-pr.png)
 > 
-> 8. You will now get the option to review the changes and add an additional
+> 8. You can now go to the repository on your account and click "New Pull Request" button, 
+>    where you can select base branches repositories, review the changes and add an additional
 >    explanation before sending the pull request (this is especially useful
 >    if you make a single pull request for multiple commits).
 > 9. Your partner should now see a pull request under the "Pull requests" tab


### PR DESCRIPTION
In Library carpentry Introduction to Git lesson 5 - GitHub Pages, the contributing to page owned by someone else, figuring out how to make a PR to owner could be a bit difficult. By following the instruction from the lesson, we are able to make a PR in our own repo to master/other branches instead of making to the original repo of the owner. So when the owner tries to approve the PR, they don't see any PR requested.

![git_collab_2](https://user-images.githubusercontent.com/32081283/80260863-7a8f3c80-864e-11ea-9b0c-d1470606083f.PNG)

Instead, I think, we can suggest the learners to commit the new change and then go to the repo and click `New Pull Request` button which will take us to a web page from where we can make a PR to owner's repo.

![git_collab](https://user-images.githubusercontent.com/32081283/80260913-98f53800-864e-11ea-889c-679f209b34a5.PNG)

Also, the spelling of "Practice" is wrongly spelled as "practise" in Challenge: Contributing to a page owned by someone else (slightly easier way) section