### PR TITLE
switch default branch name to main instead of master

### DIFF
--- a/_episodes/02-getting-started.md
+++ b/_episodes/02-getting-started.md
@@ -79,9 +79,25 @@ nothing to commit (create/copy files and use "git add" to track)
 ~~~
 {: .output}
 
-The output tells us that we are on the master branch (more on this later) and that we have nothing to commit (no 
-unsaved changes).
+The output tells us that we are on the master branch and that we have nothing to commit (no 
+unsaved changes, more on this later).
 
+### Changing the branch name
+
+The current default branch in git is master, however this [convention is changing](https://www.bbc.com/news/technology-53050955) to stop using this racist naming convention as the default in data science and software development. 
+
+To change the name of the branch, we can use `checkout` to create a new branch with the `-b` flag and provide it with our new branch name of `main`.
+
+~~~
+$ git checkout -b main
+~~~
+{: .bash}
+~~~
+On branch main
+No commits yet
+nothing to commit (create/copy files and use "git add" to track)
+~~~
+{: .output}
 
 ### Adding and committing
 
@@ -105,7 +121,7 @@ $ git status
 ~~~
 {: .bash}
 ~~~
-On branch master
+On branch main
 No commits yet
 Untracked files:
   (use "git add <file>..." to include in what will be committed)
@@ -132,7 +148,7 @@ $ git status
 ~~~
 {: .bash}
 ~~~
-On branch master
+On branch main
 
 No commits yet
 
@@ -155,7 +171,7 @@ $ git status
 ~~~
 {: .bash}
 ~~~
-On branch master
+On branch main
 
 No commits yet
 
@@ -191,7 +207,7 @@ $ git commit -m 'Add index.md'
 ~~~
 {: .bash}
 ~~~
-[master (root-commit) e9e8fd3] Add index.md
+[main (root-commit) e9e8fd3] Add index.md
  1 file changed, 1 insertion(+)
  create mode 100644 index.md
 ~~~

--- a/_episodes/03-sharing.md
+++ b/_episodes/03-sharing.md
@@ -103,7 +103,7 @@ will have to "push" our local changes to the GitHub repository. We do this using
 `git push` command:
 
 ~~~
-$ git push -u origin master
+$ git push -u origin main
 ~~~
 {: .bash}
 ~~~
@@ -111,12 +111,12 @@ Counting objects: 3, done.
 Writing objects: 100% (3/3), 226 bytes | 0 bytes/s, done.
 Total 3 (delta 0), reused 0 (delta 0)
 To https://github.com/<your_github_username/hello-world
- * [new branch]      master -> master
-Branch master set up to track remote branch master from origin.
+ * [new branch]      main -> main
+Branch main set up to track remote branch main from origin.
 ~~~
 {: .output}
 
-The nickname of our remote repository is "origin" and the default local branch name is "master".
+The nickname of our remote repository is "origin" and the local branch name is "main" because that is the name we gave it in the previous section.
 The `-u` flag tells git to remember the parameters, so that next time we can simply run `git push`
 and Git will know what to do.
 
@@ -131,13 +131,13 @@ $ git status
 ~~~
 {: .bash}
 ~~~
-On branch master
-Your branch is up-to-date with 'origin/master'.
+On branch main
+Your branch is up-to-date with 'origin/main'.
 nothing to commit, working tree clean
 ~~~
 {: .output}
 
-This output lets us know where we are working (the master branch). We can also see that we have no changes to commit 
+This output lets us know where we are working (the main branch). We can also see that we have no changes to commit 
 and everything is in order.
 
 We can use the `git diff` command to see changes we have made before making a commit. Open index.md with any text 
@@ -237,7 +237,7 @@ Counting objects: 3, done.
 Writing objects: 100% (3/3), 272 bytes | 0 bytes/s, done.
 Total 3 (delta 0), reused 0 (delta 0)
 To https://github.com/<your_github_username>/hello-world
-   e9e8fd3..8e2eb99  master -> master
+   e9e8fd3..8e2eb99  main -> main
 ~~~
 {: .output}
 
@@ -272,7 +272,7 @@ remote: Compressing objects: 100% (2/2), done.
 remote: Total 3 (delta 0), reused 0 (delta 0), pack-reused 0
 Unpacking objects: 100% (3/3), done.
 From https://github.com/<your_github_username>/hello-world
-   8e2eb99..0f5a7b0  master     -> origin/master
+   8e2eb99..0f5a7b0  main     -> origin/main
 Updating 8e2eb99..0f5a7b0
 Fast-forward
  README.md | 1 +

--- a/_episodes/05-github-pages.md
+++ b/_episodes/05-github-pages.md
@@ -46,7 +46,7 @@ There are various options for setting up a GitHub Pages site. Let's run through 
 
 GitHub Pages uses a special branch in your GitHub repository to look for website content,
 and by default this is the branch with the name 'gh-pages'.
-You can actually change this, under repository settings, to use for instance the master branch instead,
+You can actually change this, under repository settings, to use for instance the main branch instead,
 but let's stick with the default for now.
 
 It's possible to create a new branch directly on GitHub, but we will use the command line now.
@@ -86,8 +86,8 @@ Branch gh-pages set up to track remote branch gh-pages from origin.
 ~~~
 {: .output}
 
-You might remember from earlier that we did `git push -u origin master` to
-set up the master branch. The `-u` is a shorthand for `--set-upstream`, so
+You might remember from earlier that we did `git push -u origin main` to
+set up the main branch. The `-u` is a shorthand for `--set-upstream`, so
 above you could also have typed `git push -u origin gh-pages`.
 
 And remember, we only have to do this the first time we push to a new branch.


### PR DESCRIPTION
Suggest introducing branch naming to switch the default branch name to 'main' instead of 'master' throughout the lesson so that we are not teaching racist naming conventions.