### PR TITLE
adding lifecycle info to _config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,6 +12,9 @@ carpentry: "lc"
 # Overall title for pages.
 title: "Library Carpentry: Introduction to Git"
 
+# Life cycle stage of the lesson
+# possible values: "pre-alpha", "alpha", "beta", "stable"
+life_cycle: "stable"
 
 #------------------------------------------------------------
 # Generic settings (should not need to change).


### PR DESCRIPTION
Excellent @dcmcand  and @libcce!  Thanks for the info. This PR adds the lifecycle info to `_config.yml` and sets to **stable**.  This is a relatively new setting in the config. We should also change the status on here: https://librarycarpentry.org/lessons/ to let folks know it is stable.  This closes #84. 