### PR TITLE
Explain usage of the **upstream** keyword

### DIFF
--- a/_episodes/03-sharing.md
+++ b/_episodes/03-sharing.md
@@ -118,13 +118,17 @@ Branch master set up to track remote branch master from origin.
 
 The nickname of our remote repository is "origin" and the default local branch name is "master".
 The `-u` flag tells git to remember the parameters, so that next time we can simply run `git push`
-and Git will know what to do.
+and Git will know what to do. 
+
+Pushing our local changes to the Github repository is sometimes referred to as "pushing changes `upstream` to Github". 
+The word `upstream` here comes from the git flag we used earlier in the command `git push -u origin master`. 
+The flag `-u` refers to `-set-upstream`, so when we say pushing changes upstream, it refers to the remote repository. 
 
 You may be prompted to enter your GitHub username and password to complete the command.
 
 When we do a `git push`, we will see Git 'pushing' changes upstream to GitHub. Because our file is very small, this 
 won't take long but if we had made a lot of changes or were adding a very large repository, we might have to wait a 
-little longer. We can check where we're at with `git status`.
+little longer. We can check where we're at with `git status`. 
 
 ~~~
 $ git status


### PR DESCRIPTION
This PR addresses https://github.com/LibraryCarpentry/lc-git/issues/77. 

The `upstream` word needs to be explained as it is not clear "where" it comes from, to new users of git.

Please delete this line and the text below before submitting your contribution.

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.  

---
