### PR TITLE
Update setup.md

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -28,3 +28,10 @@ For example:
 $ git config --global core.editor "notepad"
 ~~~
 {: .bash}
+You will NOT get an immediate error message if you specify an incorrect or non-existent text editor command here. Therefore, you may first wish to test that the text editor you specify can be invoked, with (for the above example of `"notepad"` on Windows):
+
+~~~
+$ touch deleteme.txt
+$ notepad deleteme.txt 
+~~~
+{: .bash}


### PR DESCRIPTION
Changing of the default editor will apparently accept ANY argument, even if that then won’t work – for instance, it happily accepts:

git config --global core.editor "foobar"

too, but there’s no step for testing that in the instructions. That step has been added here.

Please delete this line and the text below before submitting your contribution.

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.  

---
