### PR TITLE
Change text of three episodes to replace 'master' with 'main'

### DIFF
--- a/_episodes/02-getting-started.md
+++ b/_episodes/02-getting-started.md
@@ -73,13 +73,13 @@ $ git status
 ~~~
 {: .language-bash }
 ~~~
-On branch master
+On branch main
 No commits yet
 nothing to commit (create/copy files and use "git add" to track)
 ~~~
 {: .output}
 
-The output tells us that we are on the master branch (more on this later) and that we have nothing to commit (no
+The output tells us that we are on the main branch (more on this later) and that we have nothing to commit (no
 unsaved changes).
 
 
@@ -105,7 +105,7 @@ $ git status
 ~~~
 {: .language-bash }
 ~~~
-On branch master
+On branch main
 No commits yet
 Untracked files:
   (use "git add <file>..." to include in what will be committed)
@@ -132,7 +132,7 @@ $ git status
 ~~~
 {: .language-bash }
 ~~~
-On branch master
+On branch main
 
 No commits yet
 
@@ -155,7 +155,7 @@ $ git status
 ~~~
 {: .language-bash }
 ~~~
-On branch master
+On branch main
 
 No commits yet
 
@@ -191,7 +191,7 @@ $ git commit -m 'Add index.md'
 ~~~
 {: .language-bash }
 ~~~
-[master (root-commit) e9e8fd3] Add index.md
+[main (root-commit) e9e8fd3] Add index.md
  1 file changed, 1 insertion(+)
  create mode 100644 index.md
 ~~~

--- a/_episodes/03-sharing.md
+++ b/_episodes/03-sharing.md
@@ -103,7 +103,7 @@ will have to "push" our local changes to the GitHub repository. We do this using
 `git push` command:
 
 ~~~
-$ git push -u origin master
+$ git push -u origin main
 ~~~
 {: .language-bash }
 ~~~
@@ -111,17 +111,17 @@ Counting objects: 3, done.
 Writing objects: 100% (3/3), 226 bytes | 0 bytes/s, done.
 Total 3 (delta 0), reused 0 (delta 0)
 To https://github.com/<your_github_username/hello-world
- * [new branch]      master -> master
-Branch master set up to track remote branch master from origin.
+ * [new branch]      main -> main
+Branch main set up to track remote branch main from origin.
 ~~~
 {: .output}
 
-The nickname of our remote repository is "origin" and the default local branch name is "master".
+The nickname of our remote repository is "origin" and the default local branch name is "main".
 The `-u` flag tells git to remember the parameters, so that next time we can simply run `git push`
 and Git will know what to do.
 
 Pushing our local changes to the Github repository is sometimes referred to as "pushing changes `upstream` to Github".
-The word `upstream` here comes from the git flag we used earlier in the command `git push -u origin master`.
+The word `upstream` here comes from the git flag we used earlier in the command `git push -u origin main`.
 The flag `-u` refers to `-set-upstream`, so when we say pushing changes upstream, it refers to the remote repository.
 
 You may be prompted to enter your GitHub username and password to complete the command.
@@ -135,13 +135,13 @@ $ git status
 ~~~
 {: .language-bash }
 ~~~
-On branch master
-Your branch is up-to-date with 'origin/master'.
+On branch main
+Your branch is up-to-date with 'origin/main'.
 nothing to commit, working tree clean
 ~~~
 {: .output}
 
-This output lets us know where we are working (the master branch). We can also see that we have no changes to commit
+This output lets us know where we are working (the main branch). We can also see that we have no changes to commit
 and everything is in order.
 
 We can use the `git diff` command to see changes we have made before making a commit. Open index.md with any text
@@ -241,7 +241,7 @@ Counting objects: 3, done.
 Writing objects: 100% (3/3), 272 bytes | 0 bytes/s, done.
 Total 3 (delta 0), reused 0 (delta 0)
 To https://github.com/<your_github_username>/hello-world
-   e9e8fd3..8e2eb99  master -> master
+   e9e8fd3..8e2eb99  main -> main
 ~~~
 {: .output}
 
@@ -276,7 +276,7 @@ remote: Compressing objects: 100% (2/2), done.
 remote: Total 3 (delta 0), reused 0 (delta 0), pack-reused 0
 Unpacking objects: 100% (3/3), done.
 From https://github.com/<your_github_username>/hello-world
-   8e2eb99..0f5a7b0  master     -> origin/master
+   8e2eb99..0f5a7b0  main     -> origin/main
 Updating 8e2eb99..0f5a7b0
 Fast-forward
  README.md | 1 +

--- a/_episodes/05-github-pages.md
+++ b/_episodes/05-github-pages.md
@@ -46,7 +46,7 @@ There are various options for setting up a GitHub Pages site. Let's run through 
 
 GitHub Pages uses a special branch in your GitHub repository to look for website content,
 and by default this is the branch with the name 'gh-pages'.
-You can actually change this, under repository settings, to use for instance the master branch instead,
+You can actually change this, under repository settings, to use for instance the main branch instead,
 but let's stick with the default for now.
 
 It's possible to create a new branch directly on GitHub, but we will use the command line now.
@@ -86,8 +86,8 @@ Branch gh-pages set up to track remote branch gh-pages from origin.
 ~~~
 {: .output}
 
-You might remember from earlier that we did `git push -u origin master` to
-set up the master branch. The `-u` is a shorthand for `--set-upstream`, so
+You might remember from earlier that we did `git push -u origin main` to
+set up the main branch. The `-u` is a shorthand for `--set-upstream`, so
 above you could also have typed `git push -u origin gh-pages`.
 
 And remember, we only have to do this the first time we push to a new branch.
@@ -115,7 +115,7 @@ Usually it's available instantly, but it can take a few seconds and in the worst
 >    You can preview how it will look before you commit changes.
 > 5. Once you are ready to commit, enter a short commit message,
 >    select "Create a new branch for this commit and start a pull request"
->    and press "Propose file change" to avoid commiting directly to the master branch.
+>    and press "Propose file change" to avoid commiting directly to the main branch.
 >
 >    ![Commit and create pull request](../fig/github-commit-pr.png)
 >


### PR DESCRIPTION
Just taught this lesson and thought I would submit this right away! This replaces all text instances where the word "master" needed to be changed to "main" to reflect new git standards. I did not change the image in episode 2 (described in issue #99 ) as I was not sure what the best solution was. Happy to work on that too but thought it might best be handled separately.

