### PR TITLE
modify setup page with new init.defaultBranch main instructions

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -12,11 +12,14 @@ If you haven't done so already, to follow this lesson you will need to:
 ~~~
 $ git config --global user.name "Your Name"
 $ git config --global user.email "your@email"
+$ git config --global init.defaultBranch main
 ~~~
 {: .language-bash }
 
 This user name and email will be recorded with each commit in the history of your repositories.
 The email address should be the same one you used when setting up your GitHub account.
+
+The `init.defaultBranch` value configures git to set the default branch to `main` instead of `master`.
 
 By default, Git will open the Vi / Vim text editor to request commit messages (for example when merging conflicts).
 To avoid confusion, most people will want to change the default editor to something more familiar using the `core.editor` config.


### PR DESCRIPTION
Addresses issue https://github.com/LibraryCarpentry/lc-git/issues/99

Git now includes a global setting `init.defaultBranch` for setting "main" as the default branch name for new local repositories. [More Info.](https://github.blog/2020-07-27-highlights-from-git-2-28/#introducing-init-defaultbranch).

See also: https://github.com/github/renaming

This adds an additional line of code to the setup page as well as an explanation of the code in the following paragraph. This issue caused some confusion while teaching the lesson to beginners. Maintainers may want to consider going into more detail if they think it's appropriate.