### PR TITLE
Update 03-sharing.md

### DIFF
--- a/_episodes/03-sharing.md
+++ b/_episodes/03-sharing.md
@@ -92,8 +92,8 @@ $ git remote -v
 ~~~
 {: .language-bash }
 ~~~
-origin  https://github.com/<your_github_username>/hello-world (fetch)
-origin  https://github.com/<your_github_username>/hello-world (push)
+origin  git@github.com:<your_github_username>/hello-world.git (fetch)
+origin  git@github.com:<your_github_username>/hello-world.git (push)
 ~~~
 {: .output}
 


### PR DESCRIPTION
Remote verbose text displayed as HTTPS, but new instructions are adding it as ssh.  Adjusted to match.

