### PR TITLE
link to GitHub guide on contributing to a project

### DIFF
--- a/_episodes/05-github-pages.md
+++ b/_episodes/05-github-pages.md
@@ -118,11 +118,12 @@ Usually it's available instantly, but it can take a few seconds and in the worst
 > Instead of making edits on the GitHub website you can 'clone' the fork to your local machine
 > and work there.
 >
-> Try following the rest of the steps under "Time to Submit Your First PR"
-> at this guide: <https://www.thinkful.com/learn/github-pull-request-tutorial/Writing-a-Good-Commit-Message#Time-to-Submit-Your-First-PR>
+> Try following the rest of the steps in this guide:
+> <https://docs.github.com/en/get-started/quickstart/contributing-to-projects>
 >
 > (If you followed step 1 and 2 in the previous challenge, you already have a fork and you can
-> skip the creation of a new fork if you like. You can submit multiple pull requests using the same fork.)
+> skip the creation of a new fork, starting instead at the section titled "Cloning a fork", if you like. 
+> You can submit multiple pull requests using the same fork.)
 >
 {: .challenge}
 

--- a/_episodes/05-github-pages.md
+++ b/_episodes/05-github-pages.md
@@ -120,12 +120,12 @@ Usually it's available instantly, but it can take a few seconds and in the worst
 >
 > Try following the steps in [GitHub's quickstart guide for contributing to projects](https://docs.github.com/en/get-started/quickstart/contributing-to-projects)
 >
-> (If you followed step 1 and 2 in the previous challenge, you already have a fork and you can
-> skip the creation of a new fork, starting instead at the section titled "Cloning a fork", if you like. 
+> (If you followed step 1 and 2 in the previous challenge,
+> you already have a fork and you can skip the creation of a new fork. 
+> Start instead at the section titled "Cloning a fork." 
 > You can submit multiple pull requests using the same fork.)
 >
 {: .challenge}
-
 
 > ## Optional challenge: Adding an HTML page
 >

--- a/_episodes/05-github-pages.md
+++ b/_episodes/05-github-pages.md
@@ -118,7 +118,7 @@ Usually it's available instantly, but it can take a few seconds and in the worst
 > Instead of making edits on the GitHub website you can 'clone' the fork to your local machine
 > and work there.
 >
-> Try following the rest of the steps in this guide:
+> Try following the steps in this guide:
 > <https://docs.github.com/en/get-started/quickstart/contributing-to-projects>
 >
 > (If you followed step 1 and 2 in the previous challenge, you already have a fork and you can

--- a/_episodes/05-github-pages.md
+++ b/_episodes/05-github-pages.md
@@ -118,8 +118,7 @@ Usually it's available instantly, but it can take a few seconds and in the worst
 > Instead of making edits on the GitHub website you can 'clone' the fork to your local machine
 > and work there.
 >
-> Try following the steps in this guide:
-> <https://docs.github.com/en/get-started/quickstart/contributing-to-projects>
+> Try following the steps in [GitHub's quickstart guide for contributing to projects](https://docs.github.com/en/get-started/quickstart/contributing-to-projects)
 >
 > (If you followed step 1 and 2 in the previous challenge, you already have a fork and you can
 > skip the creation of a new fork, starting instead at the section titled "Cloning a fork", if you like. 


### PR DESCRIPTION
Fixes #128 by replacing the broken link to the Thinkful tutorial with a more up-to-date resource on forking, cloning, and pull requests. Hopefully this guide from GitHub is a safer bet in terms of long-term maintenance and availability.
