### PR TITLE
Update slack links

### DIFF
--- a/learners/discuss.md
+++ b/learners/discuss.md
@@ -5,7 +5,7 @@ title: Discussion
 There are many ways to discuss Library Carpentry lessons:
 
 - Join our [Gitter discussion forum](https://gitter.im/LibraryCarpentry/).
-- Join our [Slack organisation](https://swc-slack-invite.herokuapp.com/) and #libraries channel.
+- Join our [Slack organisation](https://slack-invite.carpentries.org/) and #libraries channel.
 - Stay in touch with our [Topicbox Group](https://carpentries.topicbox.com/groups/discuss-library-carpentry).
 - Follow updates on [Twitter](https://twitter.com/LibCarpentry).
 - Make a suggestion or correct an error by [raising an Issue](https://github.com/LibraryCarpentry/lc-git/issues) or [submit a pull request](https://github.com/LibraryCarpentry/lc-git/pulls).


### PR DESCRIPTION
The Carpentries recently updated their Slack domain URL and invite app URL. This PR updates the links to match the new domains.