### PR TITLE
update GitHub account setup instructions

### DIFF
--- a/learners/setup.md
+++ b/learners/setup.md
@@ -2,9 +2,49 @@
 title: Setup
 ---
 
-If you haven't done so already, to follow this lesson you will need to:
+## Installing Git
 
-1. Create a free [GitHub account](https://github.com/join) and confirm your email.
-2. Download and install Git for your operating system: [https://git-scm.com/downloads](https://git-scm.com/downloads) (*Note:* Git for Windows comes bundled with the Git BASH terminal that allows you to use UNIX-style commands on Windows)
+Since several Carpentries lessons rely on Git, please see
+[this section of the workshop template][workshop-setup] for
+instructions on installing Git for various operating systems.
+
+- [Git installation on Windows][workshop-setup]
+- [Git installation on MacOS][workshop-setup]
+- [Git installation on Linux][workshop-setup]
+
+## Creating a GitHub Account
+
+You will need an account for [GitHub](https://github.com) to follow this lesson.
+
+1. Go to <https://github.com> and follow the "Sign up" link at the top-right of the window.
+2. Follow the instructions to create an account.
+3. Verify your email address with GitHub.
+4. Configure multifactor authentication (see below).
+
+### Multi-factor Authentication
+
+In 2023, GitHub introduced a requirement for 
+all accounts to have 
+[multi-factor authentication (2FA)](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/about-two-factor-authentication) 
+configured for extra security.
+Several options exist for setting up 2FA, which are summarised here:
+
+1. If you already use an authenticator app, 
+   like [Google Authenticator](https://support.google.com/accounts/answer/1066447?hl=en&co=GENIE.Platform%3DiOS&oco=0) 
+   or [Duo Mobile](https://duo.com/product/multi-factor-authentication-mfa/duo-mobile-app) on your smartphone for example, 
+   [add GitHub to that app](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-a-totp-mobile-app).
+2. If you have access to a smartphone but do not already use an authenticator app, install one and 
+   [add GitHub to the app](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-a-totp-mobile-app).
+3. If you do not have access to a smartphone or do not want to install an authenticator app, you have two options:
+    1. [set up 2FA via text message](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-text-messages) 
+       ([list of countries where authentication by SMS is supported](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/countries-where-sms-authentication-is-supported)), or
+    2. [use a hardware security key](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-a-security-key) 
+       like [Youbikey](https://www.yubico.com/products/yubikey-5-overview/) 
+       or the [Google Titan key](https://store.google.com/us/product/titan_security_key?hl=en-US&pli=1).
+
+The GitHub documentation provides [more details about configuring 2FA](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication).
+
+[workshop-setup]: https://carpentries.github.io/workshop-template/install_instructions/#git
+
 
 


### PR DESCRIPTION
_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._

Fixes #145 

_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._

This adds guidance for learners about setting up multi-factor authentication. It outsources most of the configuration instructions to GitHub themselves, as the interface and process may change relatively often.

I also replaced the previous instructions for installing Git with links to the Git section of [the Installation Instructions page of the workshop website template](https://carpentries.github.io/workshop-template/install_instructions), as these are more comprehensive and will be updated if and when the steps change to set up command line Git.

_If any relevant discussions have taken place elsewhere, please provide links to these._

This change was discussed with Maintainers of other Git lessons in The Carpentries, and further by the @LibraryCarpentry/curriculum-advisors. 

