### PR TITLE
fix link URL for issue listing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ media, slack, newsletters, and email lists. You can also [reach us by
 email][contact].
 
 [repo]: https://github.com/LibraryCarpentry/lc-git
-[repo-issues]: https://example.com/FIXME/issues
+[repo-issues]: https://github.com/LibraryCarpentry/lc-git/issues
 [contact]: mailto:team@carpentries.org
 [cp-site]: https://carpentries.org/
 [dc-issues]: https://github.com/issues?q=user%3Adatacarpentry


### PR DESCRIPTION
_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._

Fixes #154 

_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._

It seems this link was misconfigured in #147, so the link in `CONTRIBUTING.md` was pointing to example.com instead of the lesson repository. This PR corrects the URL for the link.
