### PR TITLE
update repo issues link in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ media, slack, newsletters, and email lists. You can also [reach us by
 email][contact].
 
 [repo]: https://github.com/LibraryCarpentry/lc-git
-[repo-issues]: https://example.com/FIXME/issues
+[repo-issues]: https://github.com/LibraryCarpentry/lc-git/issues
 [contact]: mailto:team@carpentries.org
 [cp-site]: https://carpentries.org/
 [dc-issues]: https://github.com/issues?q=user%3Adatacarpentry


### PR DESCRIPTION
This fixes the repo-issues links in the CONTRIBUTING.md by replacing the `example.com/FIXME` url with the url to this lesson. 

This will fix #154