### PR TITLE
Remove Notepad for Windows

### DIFF
--- a/episodes/02-getting-started.md
+++ b/episodes/02-getting-started.md
@@ -95,13 +95,9 @@ Vi and Vim are popular editors for users of the BASH shell. If you will be using
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
 Any text editor can be made default by adding the correct file path and command line options (see [GitHub help](https://help.github.com/articles/associating-text-editors-with-git/)).
-However, the simplest `core.editor` values are `"notepad"` on Windows,  `"nano -w"` on Mac, and `"nano -w"` on Linux.
+However, the simplest `core.editor` value is  `"nano -w"` on Mac, Windows, and Linux.
 
 For example:
-
-```bash 
-$ git config --global core.editor "notepad"
-```
 
 ```bash
 $ git config --global core.editor "nano -w"


### PR DESCRIPTION
Hi, just taught this today and wondered why Windows is isolated with notepad, since nano was used in the Unix Shell lesson. So I pulled the line mentioning notepad, edited the statement to be Win, Appl and LInux, and removed the box of code.

It's a bit odd because we don't return to a text editor through the command line.  I like the way the learners can see the same effect from the gui interface of editing a file to push and commit.  So maybe there's another line left over in a different part of the lesson to also update about notepad and text editing.


@chennesy I'll add Cody, as we co-taught.