### PR TITLE
Tidy up reference page

### DIFF
--- a/learners/reference.md
+++ b/learners/reference.md
@@ -1,8 +1,6 @@
 ---
-title: 'FIXME'
+title: 'Reference'
 ---
-
-## Glossary
 
 ## Quick reference
 
@@ -102,5 +100,3 @@ Git cheat sheet handouts:
 - GitHub also has interactive tutorials for their [online version (Learning Labs)](https://lab.github.com/) and for [using Git offline (Git-It)](https://github.com/jlord/git-it-electron#git-it-desktop-app)
 - Atlassian has in depth but clear [tutorials](https://www.atlassian.com/git/tutorials) on using git
 - The [Programming Historian](https://programminghistorian.org) uses GitHub to manage lessons useful to historians and also people working in libraries. It is a useful resource for lessons but also to see GitHub in action.
-
-


### PR DESCRIPTION
This pull requests fixes two issues with the `learners/reference.md` page:

- The page title should not be "FIXME". "Reference" seems reasonable as it contains both a summary of key commands and links to further reading.
- The Glossary section has no content, so the heading should be removed. To be clear, this is not a comment on the usefulness or otherwise of having a glossary; it only reflects the fact that we do not have a glossary at the moment.
