### PR TITLE
Update GitHub Skills

### DIFF
--- a/learners/reference.md
+++ b/learners/reference.md
@@ -97,6 +97,6 @@ Git cheat sheet handouts:
 
 - The [help pages](https://help.github.com/) of GitHub are a good place to start
 - GitHub has '[activities](https://guides.github.com/activities/hello-world/)' which aim to explain how git works
-- GitHub also has interactive tutorials for their [online version (Learning Labs)](https://lab.github.com/) and for [using Git offline (Git-It)](https://github.com/jlord/git-it-electron#git-it-desktop-app)
+- GitHub also has interactive tutorials for their [online version (GitHub Skills)](https://skills.github.com/) and for [using Git offline (Git-It)](https://github.com/jlord/git-it-electron#git-it-desktop-app)
 - Atlassian has in depth but clear [tutorials](https://www.atlassian.com/git/tutorials) on using git
 - The [Programming Historian](https://programminghistorian.org) uses GitHub to manage lessons useful to historians and also people working in libraries. It is a useful resource for lessons but also to see GitHub in action.


### PR DESCRIPTION
Change outdated Learning Labs link to GitHub Skills

Closes #167 


Updated the link from Learning Lab to GitHub Skills 