### PR TITLE
Update reference to opening science book

### DIFF
--- a/learners/reference.md
+++ b/learners/reference.md
@@ -91,7 +91,7 @@ Git cheat sheet handouts:
 - [JiscMonitor/allapc](https://github.com/JiscMonitor/allapc)
 - [Python Programming for Humanities](https://www.karsdorp.io/python-course/)
 - [Code4Lib 2008 lightning talk – Git and distributed cataloging](https://galencharlton.com/blog/2008/03/code4lib-2008-lightning-talk-git-and-distributed-cataloging/)
-- [Open Science Guide](https://book.openingscience.org.s3-website-eu-west-1.amazonaws.com/)
+- [Opening Science](https://www.openingscience.org/get-the-book/)
 
 ## Further reading
 


### PR DESCRIPTION
Hey all,

This PR addresses https://github.com/LibraryCarpentry/lc-git/issues/168

The existing link did not work for me until I went through the newly proposed link first. From there you can either view the book in dynamic form as it was linked to before or use another link to get a pdf. This has been described in the issue linked here above. 

Kind regards,
Timo