### PR TITLE
Clarify explanation of staging area

### DIFF
--- a/episodes/02-getting-started.md
+++ b/episodes/02-getting-started.md
@@ -297,12 +297,12 @@ and `git commit` then *actually takes* the snapshot, and
 makes a permanent record of it (as a commit).
 If you don't have anything staged when you type `git commit`,
 Git will prompt you to use `git commit -a` or `git commit --all`,
-which is kind of like gathering *everyone* for the picture!
+which is kind of like gathering *everyone* to take a group photo!
 However, it's almost always better to
 explicitly add things to the staging area, because you might
-commit changes you forgot you made. (Going back to snapshots,
-you might get the extra with incomplete makeup walking on
-the stage for the snapshot because you used `-a`!)
+commit changes you forgot you made. (Going back to the group photo simile,
+you might get an extra with incomplete makeup walking on
+the stage for the picture because you used `-a`!)
 Try to stage things manually,
 or you might find yourself searching for "git undo commit" more
 than you would like!


### PR DESCRIPTION
The explanation of the staging area in episode 2 was reproduced from the Software Carpentry Git Novice lesson. The original wording relied on people reading "snapshot" in just the photographic sense, and understanding "the extra" in sense of an archetype ("you know, *that* guy"). But people may also be familiar with other senses of "snapshot", and I for one thought that an earlier introduction to this extra had been accidentally deleted. 

The text has since been clarified in the Software Carpentry lesson. This PR reproduces edits made in swcarpentry/git-novice@e6fe3e6 from PR swcarpentry/git-novice#707 (credit to @vyasr).

