### PR TITLE
Add callouts explaining branches

### DIFF
--- a/episodes/02-getting-started.md
+++ b/episodes/02-getting-started.md
@@ -167,8 +167,21 @@ No commits yet
 nothing to commit (create/copy files and use "git add" to track)
 ```
 
-The output tells us that we are on the main branch (more on this later) and that we have nothing to commit (no
+The output tells us that we are on the main branch and that we have nothing to commit (no
 unsaved changes).
+
+:::::::::::::::::::::::::::::::::::::::::  callout
+
+## Branches and commits
+
+Commits in Git are like snapshots of our project.
+They are ordered into sequences, or "branches", with each commit pointing back to the one before it in the branch.
+Git keeps track of the last commit in each branch with a special label;
+in this lesson we mostly use one branch with the label "main".
+
+![](fig/git-branch.svg){alt='The label ‘main’ points to commit c2; c2 points to its parent c1, which points to c0.'}
+
+::::::::::::::::::::::::::::::::::::::::::::::::::
 
 ### Two steps: Adding and committing
 

--- a/episodes/05-github-pages.md
+++ b/episodes/05-github-pages.md
@@ -143,7 +143,7 @@ allowing different sets of changes to be made in parallel.
 Later on, Git can take the changes from "patch" and merge (copy) them into the "main" branch.
 In the last challenge, GitHub did all this for us in the background.
 
-![](fig/git-branches.svg){alt='The label ‘main’ points to commit c5; c5 points to its parent c3, which points to c1, which points to c0. The label ‘patch’ points to commit c4, which points to c2, which points to c1. Commit c5 also points to c4 as a secondary parent, indicating ‘patch’ was merged into ‘main’.'}
+![](fig/git-branches.svg){alt='The label ‘main’ points to commit c5; arrows point from c5 to c3 to c1 to c0. The label ‘patch’ points to commit c4; arrows point from c4 to c2 to c1. A dotted arrow points from c5 to c4.'}
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/episodes/05-github-pages.md
+++ b/episodes/05-github-pages.md
@@ -133,6 +133,20 @@ it's more practical to grant everyone access to commit directly instead.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
+:::::::::::::::::::::::::::::::::::::::::  callout
+
+## Branching and merging
+
+Branches get their name because you can create a new one (say, "patch")
+that splits off from an existing one like "main",
+allowing different sets of changes to be made in parallel.
+Later on, Git can take the changes from "patch" and merge (copy) them into the "main" branch.
+In the last challenge, GitHub did all this for us in the background.
+
+![](fig/git-branches.svg){alt='The label ‘main’ points to commit c5; c5 points to its parent c3, which points to c1, which points to c0. The label ‘patch’ points to commit c4, which points to c2, which points to c1. Commit c5 also points to c4 as a secondary parent, indicating ‘patch’ was merged into ‘main’.'}
+
+::::::::::::::::::::::::::::::::::::::::::::::::::
+
 :::::::::::::::::::::::::::::::::::::::: challenge
 
 ## Optional challenge: Contributing to a page owned by someone else (slightly more complicated way)

--- a/episodes/fig/git-branch.svg
+++ b/episodes/fig/git-branch.svg
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   id="svg1"
+   viewBox="0 0 325.20001 73.373337"
+   sodipodi:docname="git-branches.svg"
+   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="3.2349322"
+     inkscape:cx="505.7293"
+     inkscape:cy="36.785933"
+     inkscape:window-width="1876"
+     inkscape:window-height="1052"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g9">
+    <inkscape:page
+       x="0"
+       y="0"
+       inkscape:label="1"
+       id="page1"
+       width="325.20001"
+       height="73.373337"
+       margin="0"
+       bleed="0"
+       inkscape:export-filename="git-branches-2.svg"
+       inkscape:export-xdpi="96"
+       inkscape:export-ydpi="96" />
+  </sodipodi:namedview>
+  <g
+     id="g1"
+     inkscape:groupmode="layer"
+     inkscape:label="1">
+    <path
+       id="path1"
+       d="m 17.43513,0 h 69.73909 m 29.8886,0 h 69.73909"
+       style="fill:none;stroke:#491997;stroke-width:1.19553;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,27.593333,56.552)" />
+    <path
+       id="path2"
+       d="M 12.61594,0 C 12.61594,6.96767 6.96767,12.61594 0,12.61594 -6.96767,12.61594 -12.61594,6.96767 -12.61594,0 c 0,-6.96767 5.64827,-12.61594 12.61594,-12.61594 6.96767,0 12.61594,5.64827 12.61594,12.61594 z"
+       style="fill:#fce762;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,27.593333,56.552)" />
+    <text
+       id="text2"
+       xml:space="preserve"
+       transform="matrix(1.3333333,0,0,1.3333333,19.622667,60.789333)"><tspan
+         id="tspan2"
+         style="font-variant:normal;font-weight:normal;font-size:9.96264px;font-family:'Source Code Pro',monospace;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         x="0"
+         y="0">c0</tspan></text>
+    <path
+       id="path3"
+       d="m 13.21368,0 5.66936,2.12599 v -4.25198 z"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.19553;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,27.593333,56.552)" />
+    <path
+       id="path4"
+       d="m 112.24362,0 c 0,6.96767 -5.64827,12.61594 -12.61593,12.61594 C 92.66,12.61594 87.01173,6.96767 87.01173,0 c 0,-6.96767 5.64827,-12.61594 12.61596,-12.61594 6.96766,0 12.61593,5.64827 12.61593,12.61594 z"
+       style="fill:#fce762;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,27.593333,56.552)" />
+    <text
+       id="text4"
+       xml:space="preserve"
+       transform="matrix(1.3333333,0,0,1.3333333,152.45733,60.710667)"><tspan
+         id="tspan4"
+         style="font-variant:normal;font-weight:normal;font-size:9.96264px;font-family:'Source Code Pro',monospace;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         x="0"
+         y="0">c1</tspan></text>
+    <path
+       id="path5"
+       d="m 112.84137,0 5.66936,2.12599 v -4.25198 z"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.19553;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,27.593333,56.552)" />
+    <path
+       id="path6"
+       d="m 211.8713,0 c 0,6.96767 -5.64826,12.61594 -12.61593,12.61594 -6.96768,0 -12.61595,-5.64827 -12.61595,-12.61594 0,-6.96767 5.64827,-12.61594 12.61595,-12.61594 6.96767,0 12.61593,5.64827 12.61593,12.61594 z"
+       style="fill:#fce762;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,27.593333,56.552)" />
+    <text
+       id="text6"
+       xml:space="preserve"
+       transform="matrix(1.3333333,0,0,1.3333333,285.29333,60.789333)"><tspan
+         id="tspan6"
+         style="font-variant:normal;font-weight:normal;font-size:9.96264px;font-family:'Source Code Pro',monospace;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         x="0"
+         y="0">c2</tspan></text>
+    <path
+       id="path7"
+       d="m 183.97948,27.92252 h 30.55177 v 13.89403 h -30.55177 z"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#491997;stroke-width:1.19553;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,27.593333,56.552)" />
+    <text
+       id="text7"
+       xml:space="preserve"
+       transform="matrix(1.3333333,0,0,1.3333333,277.32267,14.736)"><tspan
+         id="tspan7"
+         style="font-variant:normal;font-weight:normal;font-size:9.96264px;font-family:'Source Code Pro',monospace;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         x="0"
+         y="0">main</tspan></text>
+    <path
+       id="path8"
+       d="M 199.25537,27.32475 V 14.1701"
+       style="fill:none;stroke:#000000;stroke-width:1.19553;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,27.593333,56.552)" />
+    <path
+       id="path9"
+       d="M -1.91284,2.55046 C -1.75343,1.59402 0,0.15938 0.4782,0 0,-0.15938 -1.75343,-1.59402 -1.91284,-2.55046"
+       style="fill:none;stroke:#000000;stroke-width:0.9564;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(0,1.3333333,1.3333333,0,293.26716,37.658533)" />
+  </g>
+</svg>

--- a/episodes/fig/git-branches.svg
+++ b/episodes/fig/git-branches.svg
@@ -1,0 +1,214 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   id="svg1"
+   viewBox="0 0 325.20001 139.79067"
+   sodipodi:docname="git-branches.svg"
+   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="3.2349322"
+     inkscape:cx="505.7293"
+     inkscape:cy="36.785933"
+     inkscape:window-width="1876"
+     inkscape:window-height="1052"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g9">
+    <inkscape:page
+       x="0"
+       y="0"
+       inkscape:label="2"
+       id="page9"
+       width="325.20001"
+       height="139.79066"
+       margin="0"
+       bleed="0" />
+  </sodipodi:namedview>
+  <g
+     id="g9"
+     inkscape:groupmode="layer"
+     inkscape:label="2"
+     transform="translate(-345.20001)">
+    <path
+       id="path10"
+       d="m 17.43513,0 h 19.92525 m 29.8886,0.85039 h 19.92524 m 29.8886,0 h 69.73909"
+       style="fill:none;stroke:#491997;stroke-width:1.19553;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,372.79333,56.552)" />
+    <path
+       id="path11"
+       d="m 166.87666,-49.81384 c 20.61866,0 -0.6934,48.96345 19.92525,48.96345"
+       style="fill:none;stroke:#491997;stroke-width:1.19553;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:1.19553, 1.99255;stroke-dashoffset:0;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,372.79333,56.552)" />
+    <path
+       id="path12"
+       d="m 67.24898,-0.85039 c 20.61865,0 -0.69341,-48.96345 19.92524,-48.96345 m 29.8886,0 h 19.92525"
+       style="fill:none;stroke:#1dc5ce;stroke-width:1.19553;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,372.79333,56.552)" />
+    <path
+       id="path13"
+       d="M 12.61594,0 C 12.61594,6.96767 6.96767,12.61594 0,12.61594 -6.96767,12.61594 -12.61594,6.96767 -12.61594,0 c 0,-6.96767 5.64827,-12.61594 12.61594,-12.61594 6.96767,0 12.61594,5.64827 12.61594,12.61594 z"
+       style="fill:#fce762;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,372.79333,56.552)" />
+    <text
+       id="text13"
+       xml:space="preserve"
+       transform="matrix(1.3333333,0,0,1.3333333,364.82267,60.789333)"><tspan
+         id="tspan13"
+         style="font-variant:normal;font-weight:normal;font-size:9.96264px;font-family:'Source Code Pro',monospace;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         x="0"
+         y="0">c0</tspan></text>
+    <path
+       id="path14"
+       d="m 13.21368,0 5.66936,2.12599 v -4.25198 z"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.19553;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,372.79333,56.552)" />
+    <path
+       id="path15"
+       d="m 62.42978,0 c 0,6.96767 -5.64827,12.61594 -12.61594,12.61594 -6.96768,0 -12.61595,-5.64827 -12.61595,-12.61594 0,-6.96767 5.64827,-12.61594 12.61595,-12.61594 6.96767,0 12.61594,5.64827 12.61594,12.61594 z"
+       style="fill:#fce762;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,372.79333,56.552)" />
+    <text
+       id="text15"
+       xml:space="preserve"
+       transform="matrix(1.3333333,0,0,1.3333333,431.24,60.709333)"><tspan
+         id="tspan15"
+         style="font-variant:normal;font-weight:normal;font-size:9.96264px;font-family:'Source Code Pro',monospace;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         x="0"
+         y="0">c1</tspan></text>
+    <path
+       id="path16"
+       d="m 63.02753,0 5.66935,2.12599 v -4.25198 z"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.19553;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,372.79333,56.552)" />
+    <path
+       id="path17"
+       d="m 112.24362,-49.81384 c 0,6.96768 -5.64827,12.61595 -12.61593,12.61595 -6.96769,0 -12.61596,-5.64827 -12.61596,-12.61595 0,-6.96767 5.64827,-12.61594 12.61596,-12.61594 6.96766,0 12.61593,5.64827 12.61593,12.61594 z"
+       style="fill:#fce762;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,372.79333,56.552)" />
+    <text
+       id="text17"
+       xml:space="preserve"
+       transform="matrix(1.3333333,0,0,1.3333333,497.65733,127.20667)"><tspan
+         id="tspan17"
+         style="font-variant:normal;font-weight:normal;font-size:9.96264px;font-family:'Source Code Pro',monospace;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         x="0"
+         y="0">c2</tspan></text>
+    <path
+       id="path18"
+       d="m 112.84137,-49.81384 5.66936,2.126 v -4.25199 z"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.19553;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,372.79333,56.552)" />
+    <path
+       id="path19"
+       d="m 112.24362,0 c 0,6.96767 -5.64827,12.61594 -12.61593,12.61594 C 92.66,12.61594 87.01173,6.96767 87.01173,0 c 0,-6.96767 5.64827,-12.61594 12.61596,-12.61594 6.96766,0 12.61593,5.64827 12.61593,12.61594 z"
+       style="fill:#fce762;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,372.79333,56.552)" />
+    <text
+       id="text19"
+       xml:space="preserve"
+       transform="matrix(1.3333333,0,0,1.3333333,497.65733,60.789333)"><tspan
+         id="tspan19"
+         style="font-variant:normal;font-weight:normal;font-size:9.96264px;font-family:'Source Code Pro',monospace;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         x="0"
+         y="0">c3</tspan></text>
+    <path
+       id="path20"
+       d="m 112.84137,0 5.66936,2.12599 v -4.25198 z"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.19553;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,372.79333,56.552)" />
+    <path
+       id="path21"
+       d="m 162.05746,-49.81384 c 0,6.96768 -5.64826,12.61595 -12.61593,12.61595 -6.96768,0 -12.61595,-5.64827 -12.61595,-12.61595 0,-6.96767 5.64827,-12.61594 12.61595,-12.61594 6.96767,0 12.61593,5.64827 12.61593,12.61594 z"
+       style="fill:#fce762;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,372.79333,56.552)" />
+    <text
+       id="text21"
+       xml:space="preserve"
+       transform="matrix(1.3333333,0,0,1.3333333,564.076,127.128)"><tspan
+         id="tspan21"
+         style="font-variant:normal;font-weight:normal;font-size:9.96264px;font-family:'Source Code Pro',monospace;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         x="0"
+         y="0">c4</tspan></text>
+    <path
+       id="path22"
+       d="m 162.65521,-49.81384 5.66936,2.126 v -4.25199 z"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.19553;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,372.79333,56.552)" />
+    <path
+       id="path23"
+       d="m 211.8713,0 c 0,6.96767 -5.64826,12.61594 -12.61593,12.61594 -6.96768,0 -12.61595,-5.64827 -12.61595,-12.61594 0,-6.96767 5.64827,-12.61594 12.61595,-12.61594 6.96767,0 12.61593,5.64827 12.61593,12.61594 z"
+       style="fill:#fce762;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,372.79333,56.552)" />
+    <text
+       id="text23"
+       xml:space="preserve"
+       transform="matrix(1.3333333,0,0,1.3333333,630.49333,60.709333)"><tspan
+         id="tspan23"
+         style="font-variant:normal;font-weight:normal;font-size:9.96264px;font-family:'Source Code Pro',monospace;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         x="0"
+         y="0">c5</tspan></text>
+    <path
+       id="path24"
+       d="m 131.1768,-22.83278 h 36.52943 V -7.0558 H 131.1768 Z"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#1dc5ce;stroke-width:1.19553;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,372.79333,56.552)" />
+    <text
+       id="text24"
+       xml:space="preserve"
+       transform="matrix(1.3333333,0,0,1.3333333,552.12,79.845333)"><tspan
+         id="tspan24"
+         style="font-variant:normal;font-weight:normal;font-size:9.96264px;font-family:'Source Code Pro',monospace;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         x="0"
+         y="0">patch</tspan></text>
+    <path
+       id="path25"
+       d="m 183.97948,27.92252 h 30.55177 v 13.89403 h -30.55177 z"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#491997;stroke-width:1.19553;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,372.79333,56.552)" />
+    <text
+       id="text25"
+       xml:space="preserve"
+       transform="matrix(1.3333333,0,0,1.3333333,622.52267,14.736)"><tspan
+         id="tspan25"
+         style="font-variant:normal;font-weight:normal;font-size:9.96264px;font-family:'Source Code Pro',monospace;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         x="0"
+         y="0">main</tspan></text>
+    <path
+       id="path26"
+       d="M 149.44153,-23.43054 V -35.64372"
+       style="fill:none;stroke:#000000;stroke-width:1.19553;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,372.79333,56.552)" />
+    <path
+       id="path27"
+       d="M -1.91284,2.55046 C -1.75343,1.59402 0,0.15938 0.4782,0 0,-0.15938 -1.75343,-1.59402 -1.91284,-2.55046"
+       style="fill:none;stroke:#000000;stroke-width:0.9564;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(0,1.3333333,1.3333333,0,572.04871,104.07696)" />
+    <path
+       id="path28"
+       d="M 199.25537,27.32475 V 14.1701"
+       style="fill:none;stroke:#000000;stroke-width:1.19553;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(1.3333333,0,0,-1.3333333,372.79333,56.552)" />
+    <path
+       id="path29"
+       d="M -1.91284,2.55046 C -1.75343,1.59402 0,0.15938 0.4782,0 0,-0.15938 -1.75343,-1.59402 -1.91284,-2.55046"
+       style="fill:none;stroke:#000000;stroke-width:0.9564;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(0,1.3333333,1.3333333,0,638.46716,37.658533)" />
+  </g>
+</svg>


### PR DESCRIPTION
These changes provide the explanation of branches that is promised but not delivered in the lesson.

In order to keep the cognitive load light, I've split the explanation into two parts:

- In episode 2, following the use of `git status`, we explain branches as labelled sequences of commits. This is all we need for episodes 2-4. 
- In episode 5, following the first pull request challenge, we explain what just happened in terms of branching and merging.

Each of these is illustrated with a diagram. The first one is there primarily to make the second one seem more familiar.

- In common with how the Git Book does it, the arrows between commits point backwards in time. I've used triangular arrow heads to evoke how UML shows class inheritance: each commit "inherits" the last one then changes it a bit. The callout in episode 2 says commits point back to their parents, to explain this.
- I used a dashed arrow for the merged-parent relationship to emphasise that merging isn't a symmetrical operation.
- I have used colours from the stylesheet so they tone with the rest of the site; these choices seem to work well in both light and dark mode, normally and when viewed in greyscale.
- The alt texts describe the diagrams structurally rather than captioning them, in an attempt to improve accessibility.

Addresses #54.