### PR TITLE
Update section on system and global configuration of Git

### DIFF
--- a/episodes/02-getting-started.md
+++ b/episodes/02-getting-started.md
@@ -93,14 +93,19 @@ Let's also set our default text editor. A text editor is necessary with some of 
 ## Text editors
 
 There are a lot of text editors to choose from, and a lot of people are enthusiastic about their preferences.
-Vi and Vim are popular editors for users of the BASH shell. If you will be using Git or the Shell with a group of people for a project or for work, asking for recommendations or preferences can help you pick an editor to get started with. If you already have your favorite, then you can set it as your default editor with Git.
+
+Nano is a good choice because it works on Mac, Windows, and Linux; it runs directly in your shell; and has on-screen reminders of how to use it.
+If you followed our instructions for installing Git for Windows, it should already be your default editor.
+
+Vi and Vim also run directly in the shell and have many powerful features, but are less beginner-friendly.
+
+If you will be using Git or the Shell with a group of people for a project or for work, asking for recommendations or preferences can help you pick an editor to get started with. If you already have your favorite, then you can set it as your default editor with Git.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
 Any text editor can be made default by adding the correct file path and command line options (see [GitHub help](https://help.github.com/articles/associating-text-editors-with-git/)).
-However, the simplest `core.editor` value is  `"nano -w"` on Mac, Windows, and Linux, which will run the Nano text editor directly in your shell.
-
-For example:
+However, the simplest `core.editor` value is  `"nano -w"`, which will run the Nano text editor directly in your shell.
+To select it, type the following into your shell:
 
 ```bash
 $ git config --global core.editor "nano -w"

--- a/episodes/02-getting-started.md
+++ b/episodes/02-getting-started.md
@@ -111,13 +111,17 @@ To select it, type the following into your shell:
 $ git config --global core.editor "nano -w"
 ```
 
-Lastly, we need to set the name of our default branch to `main.`
+Lastly, we need to make sure the name of our default branch is set to `main`, as that is what GitHub uses. To do this, type the following into your shell:
 
-```bash 
+```bash
 $ git config --global init.defaultBranch main
 ```
 
-The `init.defaultBranch` value configures git to set the default branch to `main` instead of `master`.
+:::::::::::::::::::::::::::::::::::::::::  callout
+
+You may already have seen a setting for `init.defaultbranch` when you looked at your configuration earlier, overriding Git's internal default. If your system configuration sets the default branch to `main`, you don't necessarily have to set it again yourself, but doing so protects you from any system-level changes.
+
+::::::::::::::::::::::::::::::::::::::::::::::::::
 
 ### Creating a repository
 

--- a/episodes/02-getting-started.md
+++ b/episodes/02-getting-started.md
@@ -61,6 +61,8 @@ credential.https://dev.azure.com.usehttppath=true
 init.defaultbranch=master
 ```
 
+If you are using Linux or WSL 2 on Windows, you might not see any output at all.
+
 If you have different output, then you may have your Git configured already. If you have not configured Git, we will do that together now.
 First, we will tell Git our user name and email.
 

--- a/episodes/02-getting-started.md
+++ b/episodes/02-getting-started.md
@@ -42,7 +42,7 @@ credential.helper=osxkeychain
 init.defaultbranch=main
 ```
 
-On Windows, without any configuration your output might look like this:
+If you followed our instructions for installing Git for Windows, your output might look like this:
 
 ```output
 diff.astextplain.textconv=astextplain
@@ -50,15 +50,15 @@ filter.lfs.clean=git-lfs clean -- %f
 filter.lfs.smudge=git-lfs smudge -- %f
 filter.lfs.process=git-lfs filter-process
 filter.lfs.required=true
-http.sslbackend=openssl
-http.sslcainfo=C:/Program Files/Git/mingw64/ssl/certs/ca-bundle.crt
+http.sslbackend=schannel
 core.autocrlf=true
 core.fscache=true
-core.symlinks=false
+core.symlinks=true
+core.editor=nano.exe
 pull.rebase=false
-credential.helper=manager-core
+credential.helper=manager
 credential.https://dev.azure.com.usehttppath=true
-init.defaultbranch=main
+init.defaultbranch=master
 ```
 
 If you have different output, then you may have your Git configured already. If you have not configured Git, we will do that together now.

--- a/episodes/02-getting-started.md
+++ b/episodes/02-getting-started.md
@@ -39,6 +39,7 @@ On MacOS, without any configuration your output might look like this:
 
 ```output
 credential.helper=osxkeychain
+init.defaultbranch=main
 ```
 
 On Windows, without any configuration your output might look like this:


### PR DESCRIPTION
Closes #164.

In episode 2, learners are asked to inspect their current Git configuration with `git config --list`. This re-formats and concatenates the contents of the system `gitconfig` and the user's global `gitconfig` (and then any repo- or folder-specific `gitconfig` files that apply).

As research for this, I looked at a recent installation of Git on a macOS system, and also performed fresh installations on Windows following the [instructions for installing the shell as of 2026-02-25](https://github.com/carpentries/workshop-template/blob/ff5ac205834a9fe554f7fcb6aa708afbd4a87177/_includes/install_instructions/shell.html).

- I have updated the macOS output to reflect the contents of the system config that was installed at `/Library/Developer/CommandLineTools/usr/share/git-core/gitconfig`.

- I have updated the Windows output to reflect the contents of the system config at `C:\Program Files\Git\etc\gitconfig` following the above instructions with the Git for Windows v2.53.0 installer. In relation to issue #164, note that the instructions say "Let Git decide" on the default branch name, which sets `init.defaultbranch=master` (reflecting Git's internal default).

- The fresh installation of Ubuntu (24.04 LTS) on WSL 2 did not ship with a system `gitconfig`. This reflects my experience with regular installations of Ubuntu and other distributions based on it. Because of this, `git config --list` yields no output; I have added a paragraph to reflect this.

- The instructions for installing Git for Windows include selecting Nano as the `core.editor` in the system config. I am unhappy about telling people who have done this to select it again.  I have therefore expanded the callout about text editors to include a discussion of the relative merits of Nano and Vim, and mention that Nano may already be set as default. The comment about cross-platform availability sits better there. I have allowed some repetition of points made before the callout (about Vim being hard at first) and after (about Nano running in the shell) – I think the discussion inside the callout would be incomplete without those points, and those who skip the callout still need to see them – but I'm open to persuasion on that point.

- Finally, I have changed the emphasis of the part about the default branch from *setting* it to *ensuring* it, acknowledging that it may already be set to `main`. I have also added a callout explaining why *repeating* the setting in your own global config could nevertheless be useful.