### PR TITLE
Reformat Episode 4 and add instructor note

### DIFF
--- a/episodes/04-review.md
+++ b/episodes/04-review.md
@@ -21,18 +21,47 @@ exercises: 20
 
 It is likely that some things won't have stuck from the last hour. To try to reinforce how things work we can work in groups to develop diagrams to illustrate Git functions and language. This should make carrying out more complicated aspects of Git clearer in our heads.
 
+::::::::::::::::::::::::::::::::::::::: instructor
+
+### Running the review exercise over Zoom
+
+If you are teaching this lesson over Zoom, you may find it preferable to run the review exercise in one large group instead of splitting out into breakout rooms.
+One way to adapt the exercise is to set up a shared online drawing board using a service such as [Miro](https://miro.com/online-whiteboard/), and share the link so all the learners can access it.
+
+Ask the learners to recall the commands and concepts they've used and add them to the board using, say, green sticky notes for Shell commands and yellow sticky notes for Git commands. Then use this as the basis for a quiz: ask the learners to explain what a command does, or describe an action and ask which command is needed. If you ask the learners to reply using the Zoom chat or Q&A, rather than verbally, it gives everyone a chance to answer.
+
+As a next step, work together on some diagrams to illustrate key concepts such as commits and branches, the staging area, or how origin and cloned repositories relate. Use background shapes, arrows, lines and text as appropriate.
+
+Finally, ask learners to work individually on their own sections of the drawing board; you could keep a topic back from the group activity specifically for this part of the exercise, or ask the learners to come up with their own versions of the collaborative drawings.
+
+::::::::::::::::::::::::::::::::::::::::::::::::::
+
+:::::::::::::::::::::::::::::::::::::::: challenge
+
+### How would you explain it?
+
 In groups:
 
-- illustrate the concepts discussed in the first hour
+- make a list of commands and concepts we've discussed in the first hour
+- try to come up with synonyms or explanations for what the commands are doing
 - try to 'draw' what different commands mean
-- try to come up with synonyms for what the commands are doing.
+- come up with your own analogies and diagrams to explain how Git works.
 
-### Exercise - visualising git
+:::::::::::::::::::: hint
 
-In group work, spend some time trying to illustrate some of the commands we've used with Git:
+### Tips for visualising git
 
-- try to express git commands in a non 'git' way
+Here are some tips for illustrating the commands and concepts we've used with Git:
+
+- try to express Git commands in a 'non-Git' way
 - try to visualise what commits are doing to your repository
+- sketch out how information flows from one repository to another.
+
+Be as creative and artistic as you like!
+
+:::::::::::::::::::::::::
+
+::::::::::::::::::::::::::::::::::::::::::::::::::
 
 If you want to practise more, feel free to keep making changes to your file and committing those changes. If you want to explore more git commands, search for some more online or visit the [lesson resources](reference.html).
 


### PR DESCRIPTION
This PR adds an instructor note to Episode 4, containing a suggestion for how to adapt the review exercise when teaching the lesson over Zoom. The key differences in this approach are that the bulk of exercise is done in one large group, with everyone sharing access to a common virtual whiteboard, and it finishes off with some individual work on the same board.

Many thanks to you, @PhilReedData, for contributing the suggestion; please take a look and let me know how to improve this version of it.

In addition, this PR makes some adjustments to the regular version of the review exercise. Reading through the page again, I struggled with the logic of how the text before the 'Exercise' header related to the text after it – they seemed to be two different versions of the same thing. To straighten things out, I've used the new instructor note as inspiration and reformulated the two versions of the group work into a single challenge block: the first bullet list now reflects the order used in the Zoom version; and I've reframed the 'Visualising Git' exercise as a set of prompts or nudges for thinking about the second half of the challenge, and formatted it as a hint block. I think it works better like that.

Resolves #142.