### PR TITLE
Add dev container support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+FROM ghcr.io/carpentries/workbench-docker:latest
+
+##  this could be used to run userland scripts e.g.
+##  users could add specific dependencies or configurations
+##  RUN scripts/userland.sh

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+{
+    "forwardPorts": [8787],
+    "portsAttributes": {
+        "8787": {
+            "label": "RStudio Server",
+            "onAutoForward": "notify"
+        }
+    },
+    "remoteUser":"rstudio",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/home/rstudio/lessons/${localWorkspaceFolderBasename},type=bind",
+    "workspaceFolder": "/home/rstudio/lessons/${localWorkspaceFolderBasename}",
+    "mounts": [
+        "source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/home/rstudio/.ssh,type=bind,consistency=cached",
+        "source=${localEnv:HOME}${localEnv:USERPROFILE}/.gnupg,target=/home/rstudio/.gnupg,type=bind,consistency=cached"
+    ],
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": ".."
+    },
+    "postCreateCommand": {
+        "pre_echo": "echo 'Installing lesson prerequisites - please wait...'",
+        "gpg_reset": "gpgconf --kill all",
+        "lesson_deps": "Rscript /home/rstudio/.workbench/setup_lesson_deps.R",
+        "fortify": "Rscript /home/rstudio/.workbench/fortify_renv_cache.R"
+    },
+    "containerEnv": {
+        "DISABLE_AUTH": "true",
+        "GPG_TTY": "/dev/pts/0"
+    }
+}


### PR DESCRIPTION
This PR adds the `.devcontainer` folder from [carpentries/workbench-template-md](https://github.com/carpentries/workbench-template-md) to allow the lesson to be previewed in a development container.